### PR TITLE
Escape special characters in message for v2 API

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -110,6 +110,11 @@ if [ $API == 'v1' ]; then
   INPUT=$(echo -n "${INPUT}" | perl -p -e 's/([^A-Za-z0-9])/sprintf("%%%02X", ord($1))/seg')
 fi
 
+# escape special characters in json
+if [ $API == 'v2' ]; then
+  INPUT=$(echo -n "${INPUT}" | sed 's/\\/\\\\/g' | sed 's/"/\\\"/g')
+fi
+
 # replace notification boolean from 1/0 to 'true'/'false' for API v2
 if [ $API == 'v2' ]; then
   if [ $NOTIFY -eq 0 ]; then


### PR DESCRIPTION
When assembling the JSON for the v2 API request, make sure the special
characters "double quote" and "backslash" are properly escaped, to prevent
malformed JSON requests.